### PR TITLE
Update specifications files to iOS 10+

### DIFF
--- a/DPPreviewProvider/DPPreviewProvider.podspec
+++ b/DPPreviewProvider/DPPreviewProvider.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |spec|
   spec.license      = "MIT (example)"
   spec.license      = { :type => "MIT" }
   spec.author             = { "Ilya Shkolnik" => "dev@darknessproduction.com" }
-  spec.platform                = :ios, '9.0'
+  spec.platform                = :ios, '10.0'
   spec.source       = { :git => "https://github.com/ILYA2606/UIPreview.git" }
   spec.source_files  = 'Pod/Classes/**/*'
 end

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '11.0'
+platform :ios, '10.0'
 use_frameworks!
 target :UIPreview do
   pod 'SnapKit', '~> 5.0.0'


### PR DESCRIPTION
SnapKit [requires](https://github.com/SnapKit/SnapKit#requirements) iOS 10+, therefore, these specifications need to be requires iOS 10+